### PR TITLE
PORT-4341 fixed integration with empty config on start

### DIFF
--- a/changelog/PORT-4341.bugfix.md
+++ b/changelog/PORT-4341.bugfix.md
@@ -1,0 +1,1 @@
+Fixed issue where the integration did not create the integration config on creation

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -42,6 +42,7 @@ class IntegrationClientMixin:
             "installationId": self.integration_identifier,
             "installationAppType": _type,
             "changelogDestination": changelog_destination,
+            "config": {},
         }
         if port_app_config:
             json["config"] = port_app_config.to_request()


### PR DESCRIPTION
# Description

What - The integration failed because there is no field config on the integration after the init
Why - When creating the integration it did not pass the config
How - Passed empty config on start

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

