### PR TITLE
PORT-4343 resolving error for unknown default file

### DIFF
--- a/changelog/PORT-4343.bugfix.md
+++ b/changelog/PORT-4343.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue with initializePortResources that caused failure for unknown file nmaes on init

--- a/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/.port/defaults/.gitignore
+++ b/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/.port/defaults/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/port_ocean/port_defaults.py
+++ b/port_ocean/port_defaults.py
@@ -210,12 +210,12 @@ def get_port_integration_defaults(
         field_model.alias for _, field_model in Defaults.__fields__.items()
     ]
     for path in defaults_dir.iterdir():
-        if not path.is_file() or path.suffix not in ALLOWED_FILE_TYPES:
-            raise UnsupportedDefaultFileType(
-                f"Defaults directory should contain only one of the next types: {ALLOWED_FILE_TYPES}. Found: {path}"
-            )
-
         if path.stem in allowed_file_names:
+            if not path.is_file() or path.suffix not in ALLOWED_FILE_TYPES:
+                raise UnsupportedDefaultFileType(
+                    f"Defaults directory should contain only one of the next types: {ALLOWED_FILE_TYPES}. Found: {path}"
+                )
+
             if path.suffix in YAML_EXTENSIONS:
                 default_jsons[path.stem] = yaml.safe_load(path.read_text())
             else:


### PR DESCRIPTION
# Description

What - The initializePortResources failed if there is an unknown file in the  resources folder
Why - Ocean raise an error for unknown file types without checking if this file is known
How - Moved the check of the file name before the file type

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

