### PR TITLE
Using the current ocean version for ocean new deps

### DIFF
--- a/integrations/gitlab/changelog/PORT-4380.improvement.md
+++ b/integrations/gitlab/changelog/PORT-4380.improvement.md
@@ -1,0 +1,1 @@
+The ocean new command now use the current ocean version in the dependencies

--- a/port_ocean/cli/commands/new.py
+++ b/port_ocean/cli/commands/new.py
@@ -3,6 +3,7 @@
 import click
 from cookiecutter.main import cookiecutter  # type: ignore
 
+from port_ocean import __version__
 from port_ocean.cli.commands.main import cli_start, print_logo, console
 from port_ocean.cli.utils import cli_root_path
 
@@ -21,7 +22,11 @@ def new(path: str) -> None:
         "🚢 Unloading cargo... Setting up your integration at the dock.", style="bold"
     )
 
-    result = cookiecutter(f"{cli_root_path}/cookiecutter", output_dir=path)
+    result = cookiecutter(
+        f"{cli_root_path}/cookiecutter",
+        output_dir=path,
+        extra_context={"version": __version__},
+    )
     name = result.split("/")[-1]
 
     console.print(

--- a/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/pyproject.toml
+++ b/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["{{cookiecutter.full_name}} <{{cookiecutter.email}}>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = { version = "^0.1.0", extras = ["cli"] }
+port_ocean = { version = "^{{ cookiecutter.version }}", extras = ["cli"] }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2"


### PR DESCRIPTION
# Description

What - The current scaffold ocean version is outdated
Why - The ocean version is a static string
How - Using the current ocean version

## Type of change

- [X] New feature (non-breaking change which adds functionality)

