### PR TITLE
Pass resource config inside the event context

### DIFF
--- a/changelog/PORT-4398.bugfix.md
+++ b/changelog/PORT-4398.bugfix.md
@@ -1,0 +1,1 @@
+Pass resource config inside event context

--- a/changelog/PORT-4411.bugfix.md
+++ b/changelog/PORT-4411.bugfix.md
@@ -1,0 +1,1 @@
+Fix not supporting multiple relations


### PR DESCRIPTION
# Description

What - Pass resource config inside the event context
Why - In case multiple resource kinds were specified inside the app config, the resync method couldn't know for which resource block ocean referred to, by passing the resource config inside the context, the integration gets the resource config that is relevant without the need for any extra logic 
How - Create event context per resource before running the resync method

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)

