### PR TITLE
Fix entity jq parsing

### DIFF
--- a/changelog/bugfix.md
+++ b/changelog/bugfix.md
@@ -1,1 +1,1 @@
-Fixed an issue that caused the jq None values for relations to become a string of None
+Fixed an issue that caused the jq `None` values for relations to become a string with the value `"None"` instead of being interpreted as `null` in JSON

--- a/changelog/bugfix.md
+++ b/changelog/bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue that caused the jq None values for relations to become a string of None

--- a/port_ocean/core/handlers/entities_state_applier/port/order_by_entities_dependencies.py
+++ b/port_ocean/core/handlers/entities_state_applier/port/order_by_entities_dependencies.py
@@ -19,11 +19,14 @@ def order_by_entities_dependencies(entities: list[Entity]) -> list[Entity]:
         entities_map[node(entity)] = entity
 
     for entity in entities:
-        relation_target_ids = [
-            identifier
-            for relation in entity.relations.values()
-            for identifier in relation
-        ]
+        relation_target_ids: list[str] = sum(
+            [
+                identifiers if isinstance(identifiers, list) else [identifiers]
+                for identifiers in entity.relations.values()
+                if identifiers is not None
+            ],
+            [],
+        )
         related_entities = [
             related for related in entities if related.identifier in relation_target_ids
         ]

--- a/port_ocean/core/models.py
+++ b/port_ocean/core/models.py
@@ -10,7 +10,7 @@ class Entity(BaseModel):
     identifier: str
     blueprint: str
     title: str | None
-    team: str | list[str] = []
+    team: str | None | list[str | None] = []
     properties: dict[str, Any] = {}
     relations: dict[str, Any] = {}
 
@@ -18,19 +18,6 @@ class Entity(BaseModel):
     def parse_obj(cls: Type["Model"], obj: dict[Any, Any]) -> "Model":
         obj["identifier"] = str(obj.get("identifier"))
         obj["blueprint"] = str(obj.get("blueprint"))
-        if obj.get("team"):
-            team = obj.get("team")
-            obj["team"] = (
-                [str(item) for item in team]
-                if isinstance(team, list)
-                else str(obj.get("team"))
-            )
-
-        for key, value in obj.get("relations", {}).items():
-            if isinstance(value, list):
-                obj["relations"][key] = [str(item) for item in value]
-            else:
-                obj["relations"][key] = str(value)
         return super(Entity, cls).parse_obj(obj)
 
 

--- a/port_ocean/core/models.py
+++ b/port_ocean/core/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import Field
@@ -7,18 +7,12 @@ Model = TypeVar("Model", bound="BaseModel")
 
 
 class Entity(BaseModel):
-    identifier: str
-    blueprint: str
-    title: str | None
-    team: str | None | list[str | None] = []
+    identifier: Any
+    blueprint: Any
+    title: Any
+    team: str | None | list[Any] = []
     properties: dict[str, Any] = {}
     relations: dict[str, Any] = {}
-
-    @classmethod
-    def parse_obj(cls: Type["Model"], obj: dict[Any, Any]) -> "Model":
-        obj["identifier"] = str(obj.get("identifier"))
-        obj["blueprint"] = str(obj.get("blueprint"))
-        return super(Entity, cls).parse_obj(obj)
 
 
 class BlueprintRelation(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.1.3"
+version = "0.1.4dev4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - If the identifier was not found in the jq it would set a "None" as the identifier which is invalid because we dont want to create the wrong entity
Why - The fields went through a parsing that made them string if they are not
How - Changed the typing and remove the parsing

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
