### PR TITLE
moved the http client to more accessible for integrations

### DIFF
--- a/changelog/improvement.md
+++ b/changelog/improvement.md
@@ -1,0 +1,1 @@
+Moved the ocean httpx client so it will be more accessible to integrations

--- a/port_ocean/clients/port/authentication.py
+++ b/port_ocean/clients/port/authentication.py
@@ -5,7 +5,7 @@ from loguru import logger
 from pydantic import BaseModel, Field, PrivateAttr
 
 from port_ocean.clients.port.types import UserAgentType
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.utils import handle_status_code
 from port_ocean.utils import get_time
 
 

--- a/port_ocean/clients/port/client.py
+++ b/port_ocean/clients/port/client.py
@@ -7,7 +7,7 @@ from port_ocean.clients.port.mixins.integrations import IntegrationClientMixin
 from port_ocean.clients.port.types import (
     KafkaCreds,
 )
-from port_ocean.clients.port.utils import handle_status_code, http
+from port_ocean.clients.utils import handle_status_code, async_client
 from port_ocean.exceptions.clients import KafkaCredentialsNotFound
 
 
@@ -21,7 +21,7 @@ class PortClient(EntityClientMixin, IntegrationClientMixin, BlueprintClientMixin
         integration_type: str,
     ):
         self.api_url = f"{base_url}/v1"
-        self.client = http
+        self.client = async_client
         self.auth = PortAuthentication(
             self.client,
             client_id,

--- a/port_ocean/clients/port/mixins/blueprints.py
+++ b/port_ocean/clients/port/mixins/blueprints.py
@@ -4,7 +4,7 @@ import httpx
 from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.utils import handle_status_code
 from port_ocean.core.models import Blueprint
 
 

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
 from port_ocean.clients.port.types import RequestOptions, UserAgentType
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.utils import handle_status_code
 from port_ocean.core.models import Entity
 
 

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -5,7 +5,7 @@ from loguru import logger
 from starlette import status
 
 from port_ocean.clients.port.authentication import PortAuthentication
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.utils import handle_status_code
 
 if TYPE_CHECKING:
     from port_ocean.core.handlers.port_app_config.models import PortAppConfig

--- a/port_ocean/clients/utils.py
+++ b/port_ocean/clients/utils.py
@@ -14,7 +14,7 @@ def _get_http_client_context() -> httpx.AsyncClient:
     return client
 
 
-http: httpx.AsyncClient = LocalProxy(lambda: _get_http_client_context())  # type: ignore
+async_client: httpx.AsyncClient = LocalProxy(lambda: _get_http_client_context())  # type: ignore
 
 
 def handle_status_code(


### PR DESCRIPTION
# Description

What - Each integration needs to handle its own ccontext of httpx async client
Why - If there are  multiple threads (like with the kafka event listener) the httpx async client can raise error because you cannot use httpx async client from another thread
How - In ocean there is a client stored in a local proxy like the ocean & event contexts so i moved it to a more reasonable place so integrations will use it instead of handling it on their own

## Type of change

- [X] Non-breaking change

