### PR TITLE
Fix config yaml parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.2.1 (2023-08-09)
+==================
+
+### Bug Fixes
+
+- Fixed an issue causing ocean to convert the integration config objects to camelized objects
+
+
 0.2.0 (2023-08-09)
 ==================
 

--- a/changelog/1.bugfix.md
+++ b/changelog/1.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue causing ocean to make the integration config objects to camelized objects

--- a/changelog/1.bugfix.md
+++ b/changelog/1.bugfix.md
@@ -1,1 +1,0 @@
-Fixed an issue causing ocean to make the integration config objects to camelized objects

--- a/port_ocean/config/base.py
+++ b/port_ocean/config/base.py
@@ -7,6 +7,7 @@ import yaml
 from humps import decamelize
 from pydantic import BaseSettings
 from pydantic.env_settings import EnvSettingsSource, InitSettingsSource
+from pydantic.main import ModelMetaclass, BaseModel
 
 PROVIDER_WRAPPER_PATTERN = r"{{ from (.*) }}"
 PROVIDER_CONFIG_PATTERN = r"^[a-zA-Z0-9]+ .*$"
@@ -60,7 +61,9 @@ def decamelize_object(obj: Any) -> Any:
 
 
 def parse_config(
-    config: dict[str, Any], existing_data: dict[str, Any]
+    settings_model: BaseModel | ModelMetaclass,
+    config: dict[str, Any],
+    existing_data: dict[str, Any],
 ) -> dict[str, Any]:
     """
     Normalizing the config yaml file to work with snake_case and getting only the data that is missing for the settings
@@ -68,9 +71,16 @@ def parse_config(
     for key, value in config.items():
         decamelize_key = decamelize(key)
         if isinstance(value, dict):
-            existing_data[decamelize_key] = parse_config(
-                value, existing_data.get(decamelize_key, {})
-            )
+            _type: ModelMetaclass = settings_model.__annotations__[decamelize_key]
+            if isinstance(_type, ModelMetaclass):
+                existing_data[decamelize_key] = parse_config(
+                    _type, value, existing_data.get(decamelize_key, {})
+                )
+            else:
+                existing_data[decamelize_key] = {
+                    decamelize(k): v for k, v in value.items()
+                }
+
         elif isinstance(value, str):
             # If the value is a provider, we try to load it from the provider
             if provider_match := re.match(PROVIDER_WRAPPER_PATTERN, value):
@@ -95,7 +105,7 @@ def load_providers(
 ) -> dict[str, Any]:
     yaml_content = read_yaml_config_settings_source(settings, base_path)
     data = yaml.safe_load(yaml_content)
-    return parse_config(data, existing_values)
+    return parse_config(settings, data, existing_values)
 
 
 class BaseOceanSettings(BaseSettings):

--- a/port_ocean/config/base.py
+++ b/port_ocean/config/base.py
@@ -71,7 +71,9 @@ def parse_config(
     for key, value in config.items():
         decamelize_key = decamelize(key)
         if isinstance(value, dict):
-            _type: ModelMetaclass = settings_model.__annotations__[decamelize_key]
+            # If the value is ModelMetaClass typed then its a nested model, and we need to parse it
+            # If the value is a dict then we need to decamelize the keys and not recurse into the values
+            _type = settings_model.__annotations__[decamelize_key]
             if isinstance(_type, ModelMetaclass):
                 existing_data[decamelize_key] = parse_config(
                     _type, value, existing_data.get(decamelize_key, {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.2.0"
+version = "0.2.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Ocean made integration config of type object camelized
Why - the parsing iterates recursively over projects
How - If the value type in the settings is a meta class recursing else the value should not be camelized

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

