### PR TITLE
optional webhook

### DIFF
--- a/integrations/gitlab/.port/spec.yaml
+++ b/integrations/gitlab/.port/spec.yaml
@@ -1,4 +1,4 @@
-version: v0.1.8
+version: v0.1.9
 type: gitlab
 description: Gitlab integration for Port Ocean
 icon: GitLab
@@ -16,7 +16,7 @@ configurations:
     description: "Mapping of Gitlab tokens to Port Ocean tokens. example: {\"THE_GROUP_TOKEN\":[\"getport-labs/**\", \"GROUP/PROJECT PATTERN TO RUN FOR\"]}"
     sensitive: true
   - name: appHost
-    required: true
+    required: false
     type: url
     description: The host of the Port Ocean app. Used for setting up the webhooks against the Gitlab.
   - name: gitlabHost

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.9 (2023-08-11)
+==================
+
+### Improvements
+
+- Made the webhook live events feature optional
+
+
 0.1.8 (2023-08-11)
 ==================
 

--- a/integrations/gitlab/config.yaml
+++ b/integrations/gitlab/config.yaml
@@ -13,4 +13,3 @@ integration:
   # The configuration of the integration.
   config:
     tokenMapping: "{{ from env TOKEN_MAPPING }}"
-    appHost: "{{ from env APP_HOST }}"

--- a/integrations/gitlab/gitlab_integration/bootstrap.py
+++ b/integrations/gitlab/gitlab_integration/bootstrap.py
@@ -1,4 +1,5 @@
 from gitlab import Gitlab
+
 from gitlab_integration.events.event_handler import EventHandler
 from gitlab_integration.events.hooks.issues import Issues
 from gitlab_integration.events.hooks.jobs import Job
@@ -6,8 +7,6 @@ from gitlab_integration.events.hooks.merge_request import MergeRequest
 from gitlab_integration.events.hooks.pipelines import Pipelines
 from gitlab_integration.events.hooks.push import PushHook
 from gitlab_integration.gitlab_service import GitlabService
-
-from port_ocean.context.ocean import ocean
 
 event_handler = EventHandler()
 
@@ -25,13 +24,12 @@ def setup_listeners(gitlab_service: GitlabService, webhook_id: str | int) -> Non
         event_handler.on(event_ids, handler.on_hook)
 
 
-def setup_application() -> None:
-    logic_settings = ocean.integration_config
-    for token, group_mapping in logic_settings["token_mapping"].items():
-        gitlab_client = Gitlab(logic_settings["gitlab_host"], token)
-        gitlab_service = GitlabService(
-            gitlab_client, logic_settings["app_host"], group_mapping
-        )
+def setup_application(
+    token_mapping: dict[str, list[str]], gitlab_host: str, app_host: str
+) -> None:
+    for token, group_mapping in token_mapping.items():
+        gitlab_client = Gitlab(gitlab_host, token)
+        gitlab_service = GitlabService(gitlab_client, app_host, group_mapping)
         webhook_ids = gitlab_service.create_webhooks()
         for webhook_id in webhook_ids:
             setup_listeners(gitlab_service, webhook_id)

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -27,7 +27,7 @@ async def handle_webhook(group_id: str, request: Request) -> dict[str, Any]:
 async def on_start() -> None:
     logic_settings = ocean.integration_config
     if not logic_settings.get("app_host"):
-        logger.debug(
+        logger.warning(
             f"No app host provided, skipping webhook creation. {NO_WEBHOOK_WARNING}"
         )
     try:

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -10,6 +10,8 @@ from gitlab_integration.utils import get_all_services, ObjectKind
 from port_ocean.context.ocean import ocean
 from port_ocean.core.ocean_types import RAW_RESULT, ASYNC_GENERATOR_RESYNC_TYPE
 
+NO_WEBHOOK_WARNING = "Without setting up the webhook, the integration will not export live changes from the gitlab"
+
 all_tokens_services = get_all_services()
 
 
@@ -23,7 +25,22 @@ async def handle_webhook(group_id: str, request: Request) -> dict[str, Any]:
 
 @ocean.on_start()
 async def on_start() -> None:
-    setup_application()
+    logic_settings = ocean.integration_config
+    if not logic_settings.get("app_host"):
+        logger.debug(
+            f"No app host provided, skipping webhook creation. {NO_WEBHOOK_WARNING}"
+        )
+    try:
+        setup_application(
+            logic_settings["token_mapping"],
+            logic_settings["gitlab_host"],
+            logic_settings["app_host"],
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failed to setup webhook: {e}. {NO_WEBHOOK_WARNING}",
+            stack_info=True,
+        )
 
 
 @ocean.on_resync(ObjectKind.PROJECT)

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.8"
+version = "0.1.9"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 

--- a/integrations/jira/Makefile
+++ b/integrations/jira/Makefile
@@ -45,6 +45,10 @@ install:
 	$(call install_poetry) && \
 	poetry install --with dev
 
+install/prod:
+	$(call install_poetry) && \
+	poetry install --without dev --no-root --no-interaction --no-ansi --no-cache
+
 lint:
 	$(ACTIVATE) && \
 	$(call run_checks,.)

--- a/integrations/newrelic/Makefile
+++ b/integrations/newrelic/Makefile
@@ -45,6 +45,10 @@ install:
 	$(call install_poetry) && \
 	poetry install --with dev
 
+install/prod:
+	$(call install_poetry) && \
+	poetry install --without dev --no-root --no-interaction --no-ansi --no-cache
+
 lint:
 	$(ACTIVATE) && \
 	$(call run_checks,.)

--- a/integrations/pagerduty/Makefile
+++ b/integrations/pagerduty/Makefile
@@ -45,6 +45,10 @@ install:
 	$(call install_poetry) && \
 	poetry install --with dev
 
+install/prod:
+	$(call install_poetry) && \
+	poetry install --without dev --no-root --no-interaction --no-ansi --no-cache
+
 lint:
 	$(ACTIVATE) && \
 	$(call run_checks,.)


### PR DESCRIPTION
# Description

What - the app host is failing the integration to start if not set
Why - the property is required and sometimes the gitlab does not have a webhook for the groups in gitlab
How - made it so the feature is optional

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)

