### PR TITLE
Handle delete events from change log where there is no after

### DIFF
--- a/changelog/2.bugfix.md
+++ b/changelog/2.bugfix.md
@@ -1,0 +1,1 @@
+Move Resource Config Selector class to public

--- a/changelog/3.bugfix.md
+++ b/changelog/3.bugfix.md
@@ -1,0 +1,1 @@
+Handle delete events from change log where there is no after

--- a/port_ocean/core/event_listener/kafka/event_listener.py
+++ b/port_ocean/core/event_listener/kafka/event_listener.py
@@ -54,7 +54,7 @@ class KafkaEventListener(BaseEventListener):
 
     def _should_be_processed(self, msg_value: dict[Any, Any], topic: str) -> bool:
         after = msg_value.get("diff", {}).get("after", {})
-        # handles delete events from audit log where there is no after
+        # handles delete events from change log where there is no after
         if after is None:
             return False
 

--- a/port_ocean/core/event_listener/kafka/event_listener.py
+++ b/port_ocean/core/event_listener/kafka/event_listener.py
@@ -52,10 +52,13 @@ class KafkaEventListener(BaseEventListener):
 
         return KafkaConsumerConfig.parse_obj(self.event_listener_config.dict())
 
-    def should_be_processed(self, msg_value: dict[Any, Any], topic: str) -> bool:
-        integration_identifier = (
-            msg_value.get("diff", {}).get("after", {}).get("identifier")
-        )
+    def _should_be_processed(self, msg_value: dict[Any, Any], topic: str) -> bool:
+        after = msg_value.get("diff", {}).get("after", {})
+        # handles delete events from audit log where there is no after
+        if after is None:
+            return False
+
+        integration_identifier = after.get("identifier")
         if integration_identifier == self.integration_identifier and (
             "change.log" in topic
         ):
@@ -64,7 +67,7 @@ class KafkaEventListener(BaseEventListener):
         return False
 
     async def _handle_message(self, message: dict[Any, Any], topic: str) -> None:
-        if not self.should_be_processed(message, topic):
+        if not self._should_be_processed(message, topic):
             return
 
         if "change.log" in topic and message is not None:


### PR DESCRIPTION
# Description

What - Handle where the integration receive an event of deletion from the port's Kafka
Why -
How - Check whether there is after

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

